### PR TITLE
Fix model dictionary interface when no cheb coefficients

### DIFF
--- a/Starfish/__init__.py
+++ b/Starfish/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.4.0"
+__version__ = "0.4.1"
 
 from .spectrum import Spectrum
 

--- a/tests/test_models/test_models.py
+++ b/tests/test_models/test_models.py
@@ -415,3 +415,22 @@ class TestSpectrumModel:
             """
         ).strip()
         assert str(mock_model) == expected
+
+    def test_model_nocheb(self, mock_spectrum, mock_trained_emulator):
+        global_params = {"log_amp": 1, "log_ls": 1}
+        local_params = [
+            {"mu": 1e4, "log_amp": 2, "log_sigma": 2},
+            {"mu": 1.3e4, "log_amp": 1.5, "log_sigma": 2},
+        ]
+        model = SpectrumModel(
+            mock_trained_emulator,
+            grid_params=[6000, 4.0, 0],
+            data=mock_spectrum,
+            vz=0,
+            Av=0,
+            log_scale=-10,
+            vsini=30,
+            global_cov=global_params,
+            local_cov=local_params,
+        )
+        assert "cheb" not in model.params


### PR DESCRIPTION
Fixes #142

Preivously chebyshev coefficients were being added into the param dictionary even if they weren't present at instantiation, showing up in the params as an empty list. This PR protects that from happening with an if statement and adds a regression test.
